### PR TITLE
chore: Add dh-dkms as build dependency for Ubuntu 23.04 (Lunar)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Jeremy Soller <jeremy@system76.com>
 Build-Depends:
   debhelper (>=9),
+  dh-dkms,
   dkms
 Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/system76-io-dkms


### PR DESCRIPTION
Should fix building on Ubuntu 23.04.