### PR TITLE
Explain where Thelio Io board is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # system76-io-dkms
-DKMS module for controlling System76 Io board, which is used in System76's Thelio desktop line.
+DKMS module for controlling the System76 Io board, which is used in System76's Thelio desktop line.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # system76-io-dkms
-DKMS module for controlling System76 Io board
+DKMS module for controlling System76 Io board, which is used in System76's Thelio desktop line.


### PR DESCRIPTION
This should help clarify when this DKMS module is or is not needed

Closes https://github.com/pop-os/system76-io-dkms/issues/9